### PR TITLE
Expanded README to be more informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # Scrimba Bootcamp Progress Tracker
-Bootcamp students will contribute to this open source project, where we will build an app to keep track of activity and accomplishments in the Scrimba bootcamp.
 
-Here is some important information that should be included in a README for an open source project:
+## Summary
+Welcome! This open source project is for Scrimba Bootcamp students to get experience working with other developers, becoming familiar with the git workflow, and learning best practices for collaborative projects. Right now we will not be assigning issues or accepting pull requests from anyone other than our students. To learn more about the Scrimba Bootcamp, please visit https://v1.scrimba.com/bootcamp.
+
+Aside from the experience that students will gain through their contributions, the purpose of this project is to build an app to keep track of activity and accomplishments in the Scrimba bootcamp. Those who wish to contribute should read [this file](https://github.com/ScrimbaBootcamp/progress-tracker/README.md) in its entirety, as well as [the Contributing Guidelines](https://github.com/ScrimbaBootcamp/progress-tracker/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/ScrimbaBootcamp/progress-tracker/<!-- file name here -->). Our Contributing Guidelines will indicate that this project has [Issues](https://github.com/ScrimbaBootcamp/progress-tracker/issues), to which students should request assignment before submitting their Pull Requests. There are also detailed instructions for making contributions by using the Command Line Interface (CLI), VS Code, or GitHub Desktop.
+
+## Tech and Tools
+We will be building this app with HTML, CSS and JavaScript. As we progress, we will make decisions about package management, data storage, and authentication, likely incorporating Vite and Firebase. Presently there is no project setup that is required before adding to the codebase.
+
+## Helpful links:
+- [Contributing Guidlines](https://github.com/ScrimbaBootcamp/progress-tracker/blob/main/CONTRIBUTING.md)
+- [Code of conduct]()
+- [MIT License](https://github.com/ScrimbaBootcamp/progress-tracker/blob/main/LICENSE)
+- [Scrimba Bootcamp Discord (collaborative-work channel)](https://discord.com/channels/684009642984341525/981289757604741180)
+
+
+<!-- Here is some important information that should be included in a README for an open source project:
 
 - [x] Project title and summary
 - [ ] brief instructions on how to set up the project
@@ -12,8 +26,5 @@ Here is some important information that should be included in a README for an op
 - [x] link to the open source license
 - [x] link to community Discord, Slack group, or GitHub Discussions
 
-## Helpful links:
-[Contributing md](https://github.com/ScrimbaBootcamp/progress-tracker/blob/main/CONTRIBUTING.md)
-[Code of conduct]()
-[License](https://github.com/ScrimbaBootcamp/progress-tracker/blob/main/LICENSE)
-[Scrimba Bootcamp collaborative-work channel](https://discord.com/channels/684009642984341525/981289757604741180)
+(We can remove these comments once everything has been added)
+-->


### PR DESCRIPTION
Previously the README was more or less a checklist of things a README should include. I thought this document should inform anyone who visits the repository of the project's purpose, who may contribute, and what documentation should be digested before jumping in to the project. 

There are still some gaps to be filled in, but I think this format comes closer to the standards for a good README file.
Closes #42 